### PR TITLE
[FIX] Kiosk mode multiple check in / checkout issue

### DIFF
--- a/addons/hr_attendance/static/src/js/my_attendances.js
+++ b/addons/hr_attendance/static/src/js/my_attendances.js
@@ -11,7 +11,7 @@ var _t = core._t;
 var MyAttendances = Widget.extend({
     events: {
         "click .o_hr_attendance_sign_in_out_icon": function() {
-            this.$('.o_hr_attendance_sign_in_out_icon').attr("disabled", "disabled");
+            this.$('.o_hr_attendance_sign_in_out_icon').css('pointer-events', 'none');
             this.update_attendance();
         },
     },


### PR DESCRIPTION
kiosk mode check in / check out its creating multiple checkin /checkout

Description of the issue/feature this PR addresses:
When user click multiple times in kiosk mode check in / check out its creating multiple checkin /checkout

Current behavior before PR:
When user click multiple times in kiosk mode check in / check out its creating multiple checkin /checkout
<img width="1240" alt="before_changes" src="https://user-images.githubusercontent.com/31165531/64120569-2501d900-cdba-11e9-9bec-993685e0f175.png">
Desired behavior after PR is merged:
After changed to pointer-events its works fine!
<img width="1241" alt="after_changes" src="https://user-images.githubusercontent.com/31165531/64120579-2c28e700-cdba-11e9-8b27-1482f10902d1.png">

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
